### PR TITLE
Spaces removed

### DIFF
--- a/mflib.php
+++ b/mflib.php
@@ -1,4 +1,4 @@
-  <?php
+<?php
 /**
  * This class is a wrapper to the MediaFire.com API.
  *


### PR DESCRIPTION
I was trying to figure it out why my application was showing an error after I implemented the mediafire sdk, well, the problm was the 2 white spaces before the "<?php".  Hope this helps and prevent some issues on your projects.