### PR TITLE
exit() removed from showError()

### DIFF
--- a/mflib.php
+++ b/mflib.php
@@ -652,7 +652,12 @@ class mflib
      */
     protected function showError($errorMessage, $errorCode = "0")
     {
-        exit("Error - " . end($this->actions) . " : \"" . $errorMessage . "\" (" . $errorCode . ")");
+        $this->error = array(
+            "action" => end($this->actions),
+            "message" => $errorMessage,
+            "code" => $errorCode
+        );
+        error_log("Error - " . end($this->actions) . " : \"" . $errorMessage . "\" (" . $errorCode . ")");
     }
 
     /**


### PR DESCRIPTION
Removed exit()  from showError() and created an error attribute to mflib.
The error will still be shown because the error_log().