### PR TITLE
Update mflib.php

### DIFF
--- a/mflib.php
+++ b/mflib.php
@@ -564,11 +564,14 @@ class mflib
         /**
          * Parse the response body into array
          */
+        if (stripos($responseHeader, "Content-Encoding: gzip") !== false) {
+            $responseBody = gzdecode($responseBody);
+        }
         if (strpos($responseHeader, "application/json") !== false)
         {
             $data = json_decode($responseBody, true);
             $data = $data["response"];
-        } elseif (strpos($responseHeader, "text/xml") !== false)
+        } elseif ((strpos($responseHeader, "text/xml") !== false) || (strpos($responseHeader, "application/xml") !== false))
         {
             $data = self::xml2array(simplexml_load_string($responseBody));
         } else


### PR DESCRIPTION
Server response sometimes has "Content-Encoding: gzip" set, so necessary to unzip response body.
Also, if requested response format is xml, the header is not set as "text/xml" but "application/xml".